### PR TITLE
(fix) slice matrix when parsing

### DIFF
--- a/parser.ts
+++ b/parser.ts
@@ -58,7 +58,7 @@ export function parseMatrix(data:any[][], rows: string[], cols: string[], option
  * @returns {matrix.IMatrix}
  */
 export function parseMatrix(data:any[][], rows_or_options?: any, cols_def?: string[], options: any = {}): matrix.IMatrix {
-    const cols = cols_def ? cols_def : data.shift().slice(1);
+    const cols = cols_def ? cols_def : data.slice().shift().slice(1);
     const rows = Array.isArray(rows_or_options) ? <string[]>rows_or_options : data.map((r) => r[0]);
     if (typeof rows_or_options === 'object') {
         options = rows_or_options;


### PR DESCRIPTION
Looks like we need to .slice() data in the d3-parser utilities repo, before we remove the first row.
Shift mutates the original array.
