### PR TITLE
Fix broken type cast

### DIFF
--- a/src/link.ts
+++ b/src/link.ts
@@ -268,7 +268,7 @@ class Link {
     const $links_enter = $links.enter().append('path').on('click', (link) => {
       let e = <Event>d3.event;
       if (link.range && this.options.canSelect()) {
-        this.idtype.select(link.range, toSelectOperation(d3.event));
+        this.idtype.select(link.range, toSelectOperation(<MouseEvent>d3.event));
       }
       e.preventDefault();
       e.stopPropagation();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "es6",
     "target": "es5",
     "noImplicitAny": false,
+    "skipLibCheck":true,
     "sourceMap": true,
     "moduleResolution": "node",
     "lib": [


### PR DESCRIPTION
This is to fix the following error upon `npm run start:app`:

```
ERROR in [at-loader] ../phovea_d3/src/link.ts:271:58 
    TS2345: Argument of type 'Event | BaseEvent' is not assignable to parameter of type 'MouseEvent'.
  Type 'Event' is not assignable to type 'MouseEvent'.
    Property 'altKey' is missing in type 'Event'.
```